### PR TITLE
修复错误，refiner切换和计算

### DIFF
--- a/modules/async_worker.py
+++ b/modules/async_worker.py
@@ -310,7 +310,7 @@ def worker():
                         print(f'[Inpaint] Current inpaint model is {inpaint_patch_model_path}')
                         if refiner_model_name == 'None':
                             use_synthetic_refiner = True
-                            refiner_switch = 0.5
+                            refiner_switch = 0.8
                     else:
                         inpaint_head_model_path, inpaint_patch_model_path = None, None
                         print(f'[Inpaint] Parameterized inpaint is disabled.')
@@ -341,10 +341,10 @@ def worker():
         ip_adapter.load_ip_adapter(clip_vision_path, ip_negative_path, ip_adapter_path)
         ip_adapter.load_ip_adapter(clip_vision_path, ip_negative_path, ip_adapter_face_path)
 
-        switch = int(round(steps * refiner_switch))
-
         if advanced_parameters.overwrite_step > 0:
             steps = advanced_parameters.overwrite_step
+
+        switch = int(round(steps * refiner_switch))
 
         if advanced_parameters.overwrite_switch > 0:
             switch = advanced_parameters.overwrite_switch


### PR DESCRIPTION
修复错误，
1、局部重绘中，当refiner为空时，启用use_synthetic_refiner精炼，0.5的默认切换时机过早造成的失控，现修改为SDXL默认的0.8。
2、使用自定义步数时，切换时机计算错误，现修改为先自定义步数再计算“步数x时机”。