### PR TITLE
sd15aio add inpaint_version/set flux_aio unet dtype to default 

### DIFF
--- a/modules/async_worker.py
+++ b/modules/async_worker.py
@@ -1577,7 +1577,7 @@ def worker():
                     async_task.params_backend['base_model_gguf'] = async_task.base_model_name
                 else:
                     if async_task.task_class == 'Flux':
-                        async_task.params_backend['base_model_dtype'] = 'fp8_e4m3fn'
+                        async_task.params_backend['base_model_dtype'] = 'default'
                 if 'cn' in goals:
                     async_task.params_backend['i2i_function'] = 1 # image prompt
                     if async_task.skipping_cn_preprocessor:

--- a/workflows/flux_aio_api.json
+++ b/workflows/flux_aio_api.json
@@ -91,7 +91,7 @@
   "258": {
     "inputs": {
       "unet_name": "juggernautXL_juggXIByRundiffusion.safetensors",
-      "weight_dtype": "fp8_e4m3fn"
+      "weight_dtype": "default"
     },
     "class_type": "UNETLoader",
     "_meta": {

--- a/workflows/sd15_aio_api.json
+++ b/workflows/sd15_aio_api.json
@@ -276,8 +276,8 @@
         0
       ],
       "model": [
-        "2747",
-        1
+        "3003",
+        0
       ],
       "positive": [
         "2747",
@@ -288,7 +288,7 @@
         3
       ],
       "latent_image": [
-        "2969",
+        "3004",
         0
       ]
     },
@@ -1470,7 +1470,7 @@
       "batch_size": 1,
       "positive": "",
       "negative": "",
-      "seed": 723854978444132,
+      "seed": 989480264105587,
       "steps": 30,
       "cfg": 7,
       "denoise": 0
@@ -1991,8 +1991,8 @@
       ],
       "return_with_leftover_noise": "disable",
       "model": [
-        "2864",
-        1
+        "3003",
+        0
       ],
       "positive": [
         "2864",
@@ -2003,8 +2003,8 @@
         3
       ],
       "latent_image": [
-        "2864",
-        4
+        "3004",
+        0
       ]
     },
     "class_type": "KSamplerAdvanced",
@@ -5653,6 +5653,77 @@
     "class_type": "UpscaleModelLoader",
     "_meta": {
       "title": "Load Upscale Model"
+    }
+  },
+  "2999": {
+    "inputs": {
+      "value": "powerpaint"
+    },
+    "class_type": "easy string",
+    "_meta": {
+      "title": "i2i_inpaint_version"
+    }
+  },
+  "3000": {
+    "inputs": {
+      "comparison": "a == b",
+      "a": [
+        "2999",
+        0
+      ],
+      "b": [
+        "3002",
+        0
+      ]
+    },
+    "class_type": "easy compare",
+    "_meta": {
+      "title": "Compare"
+    }
+  },
+  "3002": {
+    "inputs": {
+      "value": "powerpaint"
+    },
+    "class_type": "easy string",
+    "_meta": {
+      "title": "String"
+    }
+  },
+  "3003": {
+    "inputs": {
+      "boolean": [
+        "3000",
+        0
+      ],
+      "on_true": [
+        "2747",
+        1
+      ],
+      "on_false": [
+        "2989",
+        0
+      ]
+    },
+    "class_type": "easy ifElse",
+    "_meta": {
+      "title": "If else"
+    }
+  },
+  "3004": {
+    "inputs": {
+      "samples": [
+        "2969",
+        0
+      ],
+      "mask": [
+        "1989",
+        0
+      ]
+    },
+    "class_type": "SetLatentNoiseMask",
+    "_meta": {
+      "title": "Set Latent Noise Mask"
     }
   }
 }


### PR DESCRIPTION
sd15aio加入重绘引擎选择。
可图aio不需要修改
fluxaio更改为支持勇士使用fluxdev_fp16模式（default），其他flux模型不受影响，comfy会自适应。